### PR TITLE
chore: add mergify auto-merge for renovate PRs

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -6,3 +6,21 @@ pull_request_rules:
       label:
         toggle:
           - conflict
+
+  - name: Automatic merge on approval
+    conditions:
+      - '#commits-behind=0'
+      - or:
+          - '#approved-reviews-by>=1'
+          - label=ci:auto-merge
+      - not:
+          and:
+            - 'head*=renovate/lockfile-maintenance-*'
+            - 'created-at>24h ago'
+      - base=master
+      - check-success=dist-files
+      - check-success=mypy
+      - check-success=pre-commit
+    actions:
+      merge:
+        method: squash

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,5 +2,10 @@
   "extends": [
     "github>Trim21/renovate-config",
     "github>Trim21/renovate-config:monthly"
-  ]
+  ],
+  "labels": [
+    "ci:auto-merge",
+    "dependencies"
+  ],
+  "prConcurrentLimit": 3
 }


### PR DESCRIPTION
Summary:
- add Mergify automatic merge rule (approval or ci:auto-merge label)
- require checks: dist-files, mypy, pre-commit
- add Renovate labels ci:auto-merge and dependencies
- set Renovate prConcurrentLimit to 3